### PR TITLE
only change mailer if environment variables are set

### DIFF
--- a/mail.php
+++ b/mail.php
@@ -23,14 +23,16 @@ declare(strict_types=1);
 /*
  * Set custom smtp credentials.
  */
-add_action('phpmailer_init', function (PHPMailer $mail) {
-    $mail->IsSMTP();
-    $mail->SMTPAuth = env('MAIL_USERNAME') && env('MAIL_PASSWORD');
+ if (env('MAIL_HOST', false) && env('MAIL_USERNAME', false) && env('MAIL_PASSWORD', false)) {
+     add_action('phpmailer_init', function (PHPMailer $mail) {
+        $mail->IsSMTP();
+        $mail->SMTPAuth = env('MAIL_USERNAME') && env('MAIL_PASSWORD');
 
-    $mail->Host = env('MAIL_HOST');
-    $mail->Port = env('MAIL_PORT', 587);
-    $mail->Username = env('MAIL_USERNAME');
-    $mail->Password = env('MAIL_PASSWORD');
+        $mail->Host = env('MAIL_HOST');
+        $mail->Port = env('MAIL_PORT', 587);
+        $mail->Username = env('MAIL_USERNAME');
+        $mail->Password = env('MAIL_PASSWORD');
 
-    return $mail;
-});
+        return $mail;
+     });
+ }


### PR DESCRIPTION
If a user doesn't set the environment variables, it shouldn't break the mail functionality all together.