### PR TITLE
Default from address to MAIL_USERNAME

### DIFF
--- a/mail.php
+++ b/mail.php
@@ -45,14 +45,12 @@ function mail_content_type()
 
 add_filter('wp_mail_content_type', 'mail_content_type');
 
-if (isset($_ENV['MAIL_FROM_ADDRESS'])) {
-    function mail_from_address()
-    {
-        return $_ENV['MAIL_FROM_ADDRESS'];
-    }
-
-    add_filter('wp_mail_from', 'mail_from_address');
+function mail_from_address()
+{
+    return $_ENV['MAIL_FROM_ADDRESS'] ?? $_ENV['MAIL_USERNAME'];
 }
+
+add_filter('wp_mail_from', 'mail_from_address');
 
 if (isset($_ENV['MAIL_FROM_NAME'])) {
     function mail_from_name()


### PR DESCRIPTION
Instead of not setting the `wp_mail_from` if the user hasn't specified a `MAIL_FROM_ADDRESS` we set it to the `MAIL_USERNAME`.